### PR TITLE
Adds port selection for interactive commandline

### DIFF
--- a/src/cliMain.ts
+++ b/src/cliMain.ts
@@ -292,10 +292,10 @@ function getDefaultDebugOptions() {
     };
 }
 
-function interactiveCommand() {
+function interactiveCommand(port:number = 8080) {
     var server = http.createServer(handleRequest);
-    server.listen(8080, function() {
-        console.log("Server listening on: http://localhost:8080");
+    server.listen(port, function() {
+        console.log("Server listening on: http://localhost:" + port);
     });
     let compileProcess = startCompileProcess(bb.currentDirectory());
     compileProcess.refresh().then(()=>{
@@ -384,10 +384,11 @@ export function run() {
     c
         .command("interactive")
         .alias("i")
+        .option("-p, --port <port>", "set port for server to listen to (default 8080)")
         .description("runs web controled build ui")
-        .action(() => {
+        .action((c) => {
             commandRunning = true;
-            interactiveCommand();
+            interactiveCommand(c["port"]);
         });
     c.command('*', null, { noHelp: true }).action((com) => {
         console.log("Invalid command " + com);


### PR DESCRIPTION
I missed ability to select port for interactive run of bobril build because I'm running several services and I have port 8080 already assigned to different web server.

It's minimalist solution without range checking (can be added), but it's not necessary though.