### PR TITLE
Fix bad letter casing for additionalResources file

### DIFF
--- a/src/cliMain.ts
+++ b/src/cliMain.ts
@@ -8,7 +8,7 @@ const path = pathPlatformDependent.posix; // This works everythere, just use for
 import * as fs from "fs";
 import * as plugins from "./pluginsLoader"
 import * as depChecker from "./dependenciesChecker"
-import {AdditionalResources}  from './AdditionalResources'
+import {AdditionalResources}  from './additionalResources'
 
 var memoryFs: { [name: string]: Buffer } = Object.create(null);
 

--- a/src/compilationCache.ts
+++ b/src/compilationCache.ts
@@ -16,7 +16,7 @@ import { DynamicBuffer } from './dynamicBuffer';
 import * as simpleHelpers from './simpleHelpers';
 import * as cssHelpers from './cssHelpers';
 import { createFileNameShortener } from './shortenFileName';
-import {AdditionalResources}  from './AdditionalResources'
+import {AdditionalResources}  from './additionalResources'
 
 function isCssByExt(name: string): boolean {
     return /\.css$/ig.test(name);

--- a/src/compileProject.ts
+++ b/src/compileProject.ts
@@ -8,7 +8,7 @@ import * as glob from "glob";
 import * as minimatch from "minimatch";
 import { deepEqual } from './deepEqual';
 import * as plugins from "./pluginsLoader";
-import {AdditionalResources}  from './AdditionalResources'
+import {AdditionalResources}  from './additionalResources'
 
 export function createProjectFromDir(path: string): bb.IProject {
     let project: bb.IProject = {


### PR DESCRIPTION
Fixes filenames letter casing on case sensitive platforms (Linux), where the bb crashes because of big letter in import of additionalResources file