### PR TITLE
bobril-build binary fix on mac

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# all sources files with unix line endings
+text eol=lf
+
+# declare bobril-build bb as binary
+bin/bb binary


### PR DESCRIPTION
fixed error when running bb on mac

“env: node\r: No such file or directory”

added .gitattributes with declaring eol and bin/bb as a binary